### PR TITLE
Fix login after authentication expiration

### DIFF
--- a/Api/Extensions/HttpClientExtensions.cs
+++ b/Api/Extensions/HttpClientExtensions.cs
@@ -98,7 +98,7 @@ namespace MandraSoft.PokemonGo.Api.Extensions
             //Check Session closed.
             if (withAuthTicket && pogoClient._authTicket.ExpireTimestampMs < (ulong)DateTime.UtcNow.ToUnixTime())
             {
-                await pogoClient.LoginPtc();
+                await pogoClient.Login();
                 await pogoClient.SetServer();
                 url = pogoClient._apiUrl;
             }


### PR DESCRIPTION
When authentication was expired, it logged in with PTC in stead of using the previous credentials.
